### PR TITLE
Fix funding persistence visibility for charging-locations and add API flow test

### DIFF
--- a/src/main/java/com/kewe/core/funding/FundingService.java
+++ b/src/main/java/com/kewe/core/funding/FundingService.java
@@ -7,13 +7,13 @@ import com.kewe.core.businessobjects.BusinessObjectTypeRepository;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -27,18 +27,15 @@ public class FundingService {
     private final AllocationRecordRepository allocationRepository;
     private final BusinessObjectRepository businessObjectRepository;
     private final BusinessObjectTypeRepository businessObjectTypeRepository;
-    private final MongoTemplate mongoTemplate;
 
     public FundingService(BudgetRecordRepository budgetRepository,
                           AllocationRecordRepository allocationRepository,
                           BusinessObjectRepository businessObjectRepository,
-                          BusinessObjectTypeRepository businessObjectTypeRepository,
-                          MongoTemplate mongoTemplate) {
+                          BusinessObjectTypeRepository businessObjectTypeRepository) {
         this.budgetRepository = budgetRepository;
         this.allocationRepository = allocationRepository;
         this.businessObjectRepository = businessObjectRepository;
         this.businessObjectTypeRepository = businessObjectTypeRepository;
-        this.mongoTemplate = mongoTemplate;
     }
 
     public List<ChargingLocationDto> findChargingLocations(String budgetPlanId) {
@@ -79,20 +76,18 @@ public class FundingService {
             }
         }
 
-        List<Document> budgets = readCollection("budgets");
-        List<Document> allocations = readCollection("allocations");
-        List<Document> filteredBudgets = filterByBudgetPlan(budgets, budgetPlanId);
-        List<Document> filteredAllocations = filterByBudgetPlan(allocations, budgetPlanId);
+        List<BudgetRecord> budgets = filterBudgetsByPlan(budgetRepository.findAll(), budgetPlanId);
+        List<AllocationRecord> allocations = filterAllocationsByPlan(allocationRepository.findAll(), budgetPlanId);
 
         Set<String> eligibleFromBudgetIds = new HashSet<>();
-        for (Document budget : filteredBudgets) {
-            resolveDimensionId(budget, dimensionIdByCode, "businessDimensionId", "dimensionId", "destinationDimensionId", "toBusinessDimensionId", "code")
+        for (BudgetRecord budget : budgets) {
+            resolveDimensionId(budget.getBusinessDimensionId(), dimensionIdByCode)
                     .ifPresent(eligibleFromBudgetIds::add);
         }
 
         Set<String> eligibleFromAllocDestIds = new HashSet<>();
-        for (Document allocation : filteredAllocations) {
-            resolveDimensionId(allocation, dimensionIdByCode, "allocatedToDimensionId", "toBusinessDimensionId", "businessDimensionId", "destinationDimensionId", "dimensionId", "code")
+        for (AllocationRecord allocation : allocations) {
+            resolveDimensionId(allocation.getAllocatedToDimensionId(), dimensionIdByCode)
                     .ifPresent(eligibleFromAllocDestIds::add);
         }
 
@@ -106,10 +101,10 @@ public class FundingService {
 
         return new ChargingLocationDebugDto(
                 dimensions.size(),
-                filteredBudgets.size(),
-                filteredAllocations.size(),
-                filteredBudgets.stream().limit(3).map(Document::toJson).toList(),
-                filteredAllocations.stream().limit(3).map(Document::toJson).toList(),
+                budgets.size(),
+                allocations.size(),
+                budgets.stream().limit(3).map(this::budgetDebugJson).toList(),
+                allocations.stream().limit(3).map(this::allocationDebugJson).toList(),
                 eligibleFromBudgetIds.stream().sorted().toList(),
                 eligibleFromAllocDestIds.stream().sorted().toList(),
                 eligibleFinal
@@ -267,34 +262,56 @@ public class FundingService {
         return value == null || value.isBlank();
     }
 
-    private List<Document> readCollection(String collectionName) {
-        return mongoTemplate.getCollection(collectionName).find().into(new java.util.ArrayList<>());
-    }
-
-    private List<Document> filterByBudgetPlan(List<Document> records, String budgetPlanId) {
+    private List<BudgetRecord> filterBudgetsByPlan(List<BudgetRecord> records, String budgetPlanId) {
         if (isBlank(budgetPlanId)) {
             return records;
         }
         String normalized = normalizePlanKey(budgetPlanId);
         return records.stream()
-                .filter(doc -> normalizePlanKey(doc.getString("budgetPlanId")).equals(normalized)
-                        || normalizePlanKey(doc.getString("budgetPlanName")).equals(normalized)
-                        || normalizePlanKey(doc.getString("budgetPlan")).equals(normalized))
+                .filter(record -> normalizePlanKey(record.getBudgetPlanId()).equals(normalized)
+                        || normalizePlanKey(record.getBudgetPlanName()).equals(normalized))
                 .toList();
     }
 
-    private Optional<String> resolveDimensionId(Document source, Map<String, String> dimensionIdByCode, String... keys) {
-        for (String key : keys) {
-            Object value = source.get(key);
-            if (!(value instanceof String stringValue) || stringValue.isBlank()) {
-                continue;
-            }
-            if (dimensionIdByCode.containsKey(stringValue.trim().toLowerCase())) {
-                return Optional.ofNullable(dimensionIdByCode.get(stringValue.trim().toLowerCase()));
-            }
-            return Optional.of(stringValue);
+    private List<AllocationRecord> filterAllocationsByPlan(List<AllocationRecord> records, String budgetPlanId) {
+        if (isBlank(budgetPlanId)) {
+            return records;
         }
-        return Optional.empty();
+        String normalized = normalizePlanKey(budgetPlanId);
+        return records.stream()
+                .filter(record -> normalizePlanKey(record.getBudgetPlanId()).equals(normalized))
+                .toList();
+    }
+
+    private Optional<String> resolveDimensionId(String rawIdOrCode, Map<String, String> dimensionIdByCode) {
+        if (rawIdOrCode == null || rawIdOrCode.isBlank()) {
+            return Optional.empty();
+        }
+        String normalized = rawIdOrCode.trim().toLowerCase();
+        if (dimensionIdByCode.containsKey(normalized)) {
+            return Optional.ofNullable(dimensionIdByCode.get(normalized));
+        }
+        return Optional.of(rawIdOrCode);
+    }
+
+    private String budgetDebugJson(BudgetRecord budget) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("id", budget.getId());
+        payload.put("businessDimensionId", budget.getBusinessDimensionId());
+        payload.put("budgetPlanId", budget.getBudgetPlanId());
+        payload.put("budgetPlanName", budget.getBudgetPlanName());
+        payload.put("amount", budget.getAmount());
+        return new Document(payload).toJson();
+    }
+
+    private String allocationDebugJson(AllocationRecord allocation) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("id", allocation.getId());
+        payload.put("budgetPlanId", allocation.getBudgetPlanId());
+        payload.put("allocatedFromDimensionId", allocation.getAllocatedFromDimensionId());
+        payload.put("allocatedToDimensionId", allocation.getAllocatedToDimensionId());
+        payload.put("amount", allocation.getAmount());
+        return new Document(payload).toJson();
     }
 
     public record ChargingLocationDto(String id, String code, String name, String type) {}

--- a/src/test/java/com/kewe/core/funding/ChargingLocationsIntegrationTest.java
+++ b/src/test/java/com/kewe/core/funding/ChargingLocationsIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -17,6 +18,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -94,6 +96,58 @@ class ChargingLocationsIntegrationTest {
                 .andExpect(jsonPath("$.eligibleFromBudgetIds.length()").value(1))
                 .andExpect(jsonPath("$.eligibleFromAllocDestIds.length()").value(1))
                 .andExpect(jsonPath("$.eligibleFinal.length()").value(2));
+    }
+
+    @Test
+    void budgetCreatedThroughApiShouldPersistAndBeUsedByChargingLocations() throws Exception {
+        allocationRepository.deleteAll();
+        budgetRepository.deleteAll();
+        businessObjectRepository.deleteAll();
+        typeRepository.deleteAll();
+
+        BusinessObjectType cc = new BusinessObjectType();
+        cc.setCode("COST_CENTER"); cc.setName("Cost Center"); cc.setStatus("Active"); cc.setObjectKind("Business Dimension");
+        typeRepository.save(cc);
+
+        String createdDimensionId = mockMvc.perform(post("/api/business-object-types/objects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "typeCode": "COST_CENTER",
+                                  "objectKind": "Business Dimension",
+                                  "code": "CC0100",
+                                  "name": "Physics",
+                                  "status": "Active"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String dimensionId = new com.fasterxml.jackson.databind.ObjectMapper().readTree(createdDimensionId).get("id").asText();
+
+        mockMvc.perform(post("/api/budgets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "businessDimensionId": "%s",
+                                  "budgetPlanId": "FY26-OPERATING",
+                                  "budgetPlanName": "FY26 Operating",
+                                  "amount": 12345
+                                }
+                                """.formatted(dimensionId)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/debug/charging-locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.budgetsCount").value(1))
+                .andExpect(jsonPath("$.allocationsCount").value(0));
+
+        mockMvc.perform(get("/api/charging-locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.code == 'CC0100')]").exists())
+                .andExpect(jsonPath("$.length()").value(1));
     }
 
 }


### PR DESCRIPTION
### Motivation
- The debug view and `/api/charging-locations` were reading different data paths so saved Budgets/Allocations in the UI were not reflected in the debug counts or charging-location results.
- The goal is to make debug/lookup logic use the same persisted repositories that the REST write endpoints use so persisted budgets/allocations are visible end-to-end.
- Add an integration test that exercises the API flow (create dimension → create budget → verify debug and charging-locations) to prevent regressions.

### Description
- Change `FundingService.collectChargingLocationDebug` to read budgets and allocations from `BudgetRecordRepository` and `AllocationRecordRepository` (instead of raw `MongoTemplate` collection reads) and filter by budget plan with repository-backed helpers.
- Remove the `MongoTemplate` usage and add `filterBudgetsByPlan`, `filterAllocationsByPlan`, `resolveDimensionId`, and small debug JSON serializers to produce stable preview payloads for the debug endpoint.
- Add an integration test `budgetCreatedThroughApiShouldPersistAndBeUsedByChargingLocations` in `ChargingLocationsIntegrationTest` that creates a Business Dimension via the API, posts a Budget to `/api/budgets`, and asserts `/api/debug/charging-locations` and `/api/charging-locations` reflect the persisted budget.
- Confirmed collection/entity and API usage: `BudgetRecord` maps to Mongo collection "budgets" and `AllocationRecord` maps to "allocations", the UI calls `/budgets`, `/allocations`, and `fetchBudgetData()` uses `/budgets/all`, and the service now reads from the same repositories those endpoints write to.

### Testing
- Added an integration test that (1) creates a Business Dimension via `/api/business-object-types/objects`, (2) creates a Budget via `POST /api/budgets`, (3) asserts `/api/debug/charging-locations` reports `budgetsCount = 1` and `allocationsCount = 0`, and (4) asserts `/api/charging-locations` returns the created dimension.
- An attempt to run `./gradlew test --tests com.kewe.core.funding.ChargingLocationsIntegrationTest` in this environment failed due to a missing Java 21 toolchain, but the new test is included and should pass in CI or local environments with the configured JDK/toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74066c8848332b22e8ee82dde4b5d)